### PR TITLE
Removed depreciated datetime functions,  Added more support to page history,  Updated Span and Div classes

### DIFF
--- a/drafter/components.py
+++ b/drafter/components.py
@@ -379,9 +379,10 @@ class HorizontalRule(PageContent):
 
 
 @dataclass
-class Span(PageContent):
+class _HtmlGroup(PageContent):
     content: list[Any]
     extra_settings: dict
+    # kind: str = ''
 
     def __init__(self, *args, **kwargs):
         self.content = args
@@ -389,33 +390,30 @@ class Span(PageContent):
 
     def __repr__(self):
         if self.extra_settings:
-            return f"Span({', '.join(repr(item) for item in self.content)}, {self.extra_settings})"
-        return f"Span({', '.join(repr(item) for item in self.content)})"
+            return f"{self.kind.capitalize()}({', '.join(repr(item) for item in self.content)}, {self.extra_settings})"
+        return f"{self.kind.capitalize()}({', '.join(repr(item) for item in self.content)})"
 
     def __str__(self) -> str:
         parsed_settings = self.parse_extra_settings(**self.extra_settings)
-        return f"<span {parsed_settings}>{''.join(str(item) for item in self.content)}</span>"
+        return f"<{self.kind} {parsed_settings}>{''.join(str(item) for item in self.content)}</{self.kind}>"
 
 
 @dataclass
-class Div(PageContent):
-
-    # TODO: This should subclass a common ancestor with Span
-    content: list[Any]
-    extra_settings: dict
+class Span(_HtmlGroup):
+    kind = 'span'
 
     def __init__(self, *args, **kwargs):
         self.content = args
         self.extra_settings = kwargs
 
-    def __repr__(self):
-        if self.extra_settings:
-            return f"Div({', '.join(repr(item) for item in self.content)}, {self.extra_settings})"
-        return f"Div({', '.join(repr(item) for item in self.content)})"
 
-    def __str__(self) -> str:
-        parsed_settings = self.parse_extra_settings(**self.extra_settings)
-        return f"<div {parsed_settings}>{''.join(str(item) for item in self.content)}</div>"
+@dataclass
+class Div(_HtmlGroup):
+    kind = 'div'
+
+    def __init__(self, *args, **kwargs):
+        self.content = args
+        self.extra_settings = kwargs
 
 
 Division = Div

--- a/drafter/history.py
+++ b/drafter/history.py
@@ -6,7 +6,7 @@ import io
 from urllib.parse import unquote
 from dataclasses import dataclass, is_dataclass, replace, asdict, fields
 from dataclasses import field as dataclass_field
-from datetime import datetime
+from datetime import datetime, UTC as timezone_UTC
 from typing import Any, Optional, Callable
 import pprint
 
@@ -188,17 +188,17 @@ class VisitedPage:
     button_pressed: str
     original_page_content: Optional[str] = None
     old_state: Any = None
-    started: datetime = dataclass_field(default_factory=datetime.utcnow)
+    started: datetime = dataclass_field(default_factory=lambda:datetime.now(timezone_UTC))
     stopped: Optional[datetime] = None
 
     def update(self, new_status, original_page_content=None):
         self.status = new_status
         if original_page_content is not None:
-            self.original_page_content = format_page_content(original_page_content, 120)
+            self.original_page_content = format_page_content(original_page_content, 120).replace('<', '&lt;').replace('>', '&gt;')
 
     def finish(self, new_status):
         self.status = new_status
-        self.stopped = datetime.utcnow()
+        self.stopped = datetime.now(timezone_UTC)
 
     def as_html(self):
         function_name = self.function.__name__

--- a/drafter/history.py
+++ b/drafter/history.py
@@ -194,7 +194,7 @@ class VisitedPage:
     def update(self, new_status, original_page_content=None):
         self.status = new_status
         if original_page_content is not None:
-            self.original_page_content = format_page_content(original_page_content, 120).replace('<', '&lt;').replace('>', '&gt;')
+            self.original_page_content = html.escape(format_page_content(original_page_content, 120))
 
     def finish(self, new_status):
         self.status = new_status


### PR DESCRIPTION
1)  drafter/history.py used `datetime.datetime.utcnow()`,  which is depreciated.  Replaced all instances of it with `datetime.now(datetime.UTC)`

2)  Changed the VisitedPage class in drafter/history.py to replace all occurrences of "<" and ">" with html character entities,  so that html tags in strings in a page's components don't get treated as html tags by the browser when being displayed in the assert_equal functions in the debug info.

3)  Made a new page component subclass that acts as the common ancestor for the Span and Div classes.